### PR TITLE
Enabling "Load on TIGERs (loaded file)" button

### DIFF
--- a/conf_GUI.py
+++ b/conf_GUI.py
@@ -1283,6 +1283,7 @@ class menu():
             GEM_NAME = str(self.showing_GEMROC.get())
             File_name = filedialog.askopenfilename(initialdir="." + sep + "conf" + sep + "saves", title="Select file", filetypes=(("Channels configuration saves", "*.cs"), ("all files", "*.*")))
             self.GEMROC_reading_dict[GEM_NAME].c_inst.load_ch_conf(File_name)
+            self.LOAD_ON['state'] = 'normal'
 
     def LOAD_on_TIGER(self):
         GEMROC = self.showing_GEMROC.get()


### PR DESCRIPTION
Added enabling "Load on TIGERs (loaded file)" button after config loading

Dear Alberto,
I'm sorry, can I suggest to enable the button for applying the per-channel settings to all tigers?
It seems, the button is functional, but currently, in "disabled" state.
Can it be loaded after config file load, or there is a reason not to enable that functionality?
Thank you!